### PR TITLE
Implemented coins and remaining base explore cards

### DIFF
--- a/game_logic.js
+++ b/game_logic.js
@@ -118,8 +118,8 @@ function startGame() {
         document.getElementById("scoreCard" + card).innerHTML = scoreCardOrder[card-1]; 
     }
 
-    cardsThisSeason = 4;
     initializeExploreDeck();
+    determineNumberOfCardsThisSeason();
     currentPiece = exploreDeck.pop();
     checkCurrentPieceCanBePlaced();
     renderPiece(currentPiece);
@@ -229,7 +229,7 @@ function renderBoard(board) {
             }
         }
         //game_page.html stores the game board in a table which has rows with id from boardRow0 to boardRow7
-        var boardRender = document.getElementById("boardRow"+i);
+        let boardRender = document.getElementById("boardRow"+i);
         boardRender.innerHTML = colourBoard;
     }
 }
@@ -259,21 +259,46 @@ function initializeScoreCards() {
 }
 
 /**
+ * Looks at the explore deck and determines, based on the season, the number of cards that will be drawn this season.
+ * The first season has a time total of 6, the second season has a time total of 5, and the third season has a time total of 4.
+ */
+function determineNumberOfCardsThisSeason() {
+    let seasonTimeTotal = 6 - seasonsScored;
+    let numberOfCards = 1;
+    let determinedNumberOfCards = false;
+    while (!determinedNumberOfCards) {
+        let totalTimeOfCards = 0;
+        for (let i = 1; i <= numberOfCards; i++) {
+            totalTimeOfCards += exploreDeck[exploreDeck.length - i].time;
+        }
+        if (totalTimeOfCards >= seasonTimeTotal) {
+            determinedNumberOfCards = true;
+            cardsThisSeason = numberOfCards;
+            document.getElementById("cardsRemaining1").innerHTML = "";
+            document.getElementById("cardsRemaining2").innerHTML = "";
+            document.getElementById("cardsRemaining3").innerHTML = "";
+            document.getElementById("cardsRemaining" + (seasonsScored + 1)).innerHTML = "Cards remaining: " + cardsThisSeason;
+        }
+        numberOfCards++;
+    }
+}
+
+/**
  * Create the explore deck by adding the base 10 pre-determined (for now) cards and shuffling.
  */
 function initializeExploreDeck() {
     exploreDeck = [];
-    exploreDeck.push({type:FOREST,  shape:[[0,0],[0,1],[1,1],[-1,0],[-2,0]],   altType:VILLAGE,               alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:FARM,    shape:[[0,0],[1,0],[-1,0],[0,1],[0,-1]],   altShape:[[0,0],[0,1]],        alt:"shape", coin:false, location:[4,4]});
-    exploreDeck.push({type:FOREST,  shape:[[0,0],[-1,0],[1,0],[1,1]],          altShape:[[0,0],[1,1]],        alt:"shape", coin:false, location:[4,4]});
-    exploreDeck.push({type:FOREST,  shape:[[0,0],[0,1],[0,2],[-1,0]],          altType:FARM,                  alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:VILLAGE, shape:[[0,0],[1,0],[-1,0],[-1,-1],[0,-1]], altShape:[[0,0],[1,0],[0,-1]], alt:"shape", coin:false, location:[4,4]});
-    exploreDeck.push({type:VILLAGE, shape:[[0,0],[-1,0],[1,0],[0,-1]],         altType:FARM,                  alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:FARM,    shape:[[0,0],[1,0],[2,0],[0,1],[0,2]],     altType:RIVER,                 alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:RIVER,   shape:[[0,0],[1,0],[1,1],[0,-1],[-1,-1]],  altShape:[[0,0],[-1,0],[1,0]], alt:"shape", coin:false, location:[4,4]});
-    exploreDeck.push({type:FOREST,  shape:[[0,0],[1,0],[-1,0],[1,1],[1,-1]],   altType:RIVER,                 alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:RIVER,   shape:[[0,0],[1,0],[2,0],[3,0]],           altType:VILLAGE,               alt:"type",  coin:false, location:[4,4]});
-    exploreDeck.push({type:FARM,    shape:[[0,0]],                             altType:FOREST,                alt:"rift",  coin:false, location:[4,4]});
+    exploreDeck.push({type:FOREST,  shape:[[0,0],[0,1],[1,1],[-1,0],[-2,0]],   altType:VILLAGE,               alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:FARM,    shape:[[0,0],[1,0],[-1,0],[0,1],[0,-1]],   altShape:[[0,0],[0,1]],        alt:"shape", coin:false, time:1, location:[4,4]});
+    exploreDeck.push({type:FOREST,  shape:[[0,0],[-1,0],[1,0],[1,1]],          altShape:[[0,0],[1,1]],        alt:"shape", coin:false, time:1, location:[4,4]});
+    exploreDeck.push({type:FOREST,  shape:[[0,0],[0,1],[0,2],[-1,0]],          altType:FARM,                  alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:VILLAGE, shape:[[0,0],[1,0],[-1,0],[-1,-1],[0,-1]], altShape:[[0,0],[1,0],[0,-1]], alt:"shape", coin:false, time:1, location:[4,4]});
+    exploreDeck.push({type:VILLAGE, shape:[[0,0],[-1,0],[1,0],[0,-1]],         altType:FARM,                  alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:FARM,    shape:[[0,0],[1,0],[2,0],[0,1],[0,2]],     altType:RIVER,                 alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:RIVER,   shape:[[0,0],[1,0],[1,1],[0,-1],[-1,-1]],  altShape:[[0,0],[-1,0],[1,0]], alt:"shape", coin:false, time:1, location:[4,4]});
+    exploreDeck.push({type:FOREST,  shape:[[0,0],[1,0],[-1,0],[1,1],[1,-1]],   altType:RIVER,                 alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:RIVER,   shape:[[0,0],[1,0],[2,0],[3,0]],           altType:VILLAGE,               alt:"type",  coin:false, time:2, location:[4,4]});
+    exploreDeck.push({type:FARM,    shape:[[0,0]],                             altType:FOREST,                alt:"rift",  coin:false, time:0, location:[4,4]});
     shuffle(exploreDeck);
 }
 
@@ -555,6 +580,10 @@ function copyBoard(copy, original) {
     renderPlayerCoins();
     //A piece has been placed so we decrement the number of explore cards (pieces) remaining until we score this season
     cardsThisSeason--;
+    document.getElementById("cardsRemaining1").innerHTML = "";
+    document.getElementById("cardsRemaining2").innerHTML = "";
+    document.getElementById("cardsRemaining3").innerHTML = "";
+    document.getElementById("cardsRemaining" + (seasonsScored + 1)).innerHTML = "Cards remaining: " + cardsThisSeason;
     return true;
 }
 
@@ -623,7 +652,7 @@ function checkIfGameOver() {
         document.getElementById("startButton").hidden=false;
     } else {
         initializeExploreDeck();
-        cardsThisSeason = 4;
+        determineNumberOfCardsThisSeason();
         currentPiece = exploreDeck.pop();
         checkCurrentPieceCanBePlaced();
         renderPiece(currentPiece);

--- a/game_logic.js
+++ b/game_logic.js
@@ -91,6 +91,9 @@ function startGame() {
         [0,0,0,0,0,0,0,0],
         [0,0,0,0,0,0,0,0]
     ];
+
+    initializeGameBoard();
+
     renderBoard(gameBoard);
 
     playerPoints = 0;
@@ -107,6 +110,64 @@ function startGame() {
     currentPiece = exploreDeck.pop();
     checkCurrentPieceCanBePlaced();
     renderPiece(currentPiece);
+}
+
+/**
+ * Initializes the game board with 2 mountains and 4 blocked spaces.
+ * First a mountain is placed on a random space that is 1 away from the edge of the game board.
+ * Then a second mountain is placed on a space that is 2 away from the edge of the game board and at least
+ * 4 spaces away vertically or horizontally from the first mountain.
+ * Lastly, 3 blocked spaces are placed on random locations that aren't cardinally adjacent to either of the mountains.
+ * @param {*} board 
+ */
+function initializeGameBoard() {
+    //(x1,y1) represents the position of the first mountain, (x2,y2) represents the position of the second mountain.
+    let x1, y1, x2, y2;
+    //Determine the axis which the first mountain will be placed along.
+    if (Math.random() <= 0.5) {
+        //x1 is randomly either 1 or 6
+        x1 = 5 * Math.round(Math.random()) + 1;
+        //y1 is random from 1 to 6
+        y1 = Math.round(5 * Math.random() + 1);
+    } else {
+        //x1 is random from 1 to 6
+        x1 = Math.round(5 * Math.random() + 1);
+        //y1 is randomly either 1 or 6
+        y1 = 5 * Math.round(Math.random()) + 1; 
+    }
+    gameBoard[x1][y1] = MOUNTAIN;
+    console.log(gameBoard);
+    let adjacentToMountain = [[x1,y1], [x1+1,y1], [x1-1,y1], [x1,y1+1], [x1,y1-1]];
+    //Determine the position of the second mountain.
+    if (x1 == 1) {
+        x2 = 5;
+        y2 = Math.round(3 * Math.random() + 2);
+    } else if (x1 == 6) {
+        x2 = 2;
+        y2 = Math.round(3 * Math.random() + 2);
+    } else if (y1 == 1) {
+        x2 = Math.round(3 * Math.random() + 2);
+        y2 = 5;
+    } else if (y1 == 6) {
+        x2 = Math.round(3 * Math.random() + 2);
+        y2 = 2;
+    }
+    gameBoard[x2][y2] = MOUNTAIN;
+    console.log(gameBoard);
+    adjacentToMountain += [[x2,y2], [x2+1,y2], [x2-1,y2], [x2,y2+1], [x2,y2-1]];
+    //Randomly place the blocked spaces.
+    let blockedPlaced = 0;
+    while (blockedPlaced < 3) {
+        let xb = Math.round(7 * Math.random());
+        let yb = Math.round(7 * Math.random());
+        if (adjacentToMountain.includes([xb,yb],0) || gameBoard[xb][yb] == BLOCKED) {
+            //Cannot place blocked piece adjacent to a mountain or over the top of another blocked piece
+            continue;
+        } else {
+            gameBoard[xb][yb] = BLOCKED;
+            blockedPlaced++;
+        }
+    }
 }
 
 /**

--- a/game_page.html
+++ b/game_page.html
@@ -33,6 +33,11 @@
             <div class="col col-md-4" id="scoreCard2">scoreCard2</div>
             <div class="col col-md-4" id="scoreCard3">scoreCard3</div>
         </div>
+        <div class="row justify-content-md-center" style="text-align:center">
+            <div class="col col-md-4" id="cardsRemaining1"></div>
+            <div class="col col-md-4" id="cardsRemaining2"></div>
+            <div class="col col-md-4" id="cardsRemaining3"></div>
+        </div>
     </div>
     <table class="board" style="margin-left:auto;margin-right:auto;">
         <tr id="boardRow0">

--- a/game_page.html
+++ b/game_page.html
@@ -61,9 +61,15 @@
         </tr>
     </table>
     <br>
-    <table style="margin-left:auto;margin-right:auto;">
+    <table style="width:120px;margin-left:auto;margin-right:auto;">
         <tr>
             <td id="playerPoints">Points: 0</td>
+        </tr>
+        <tr>
+            <td id="playerCoins">Coins: 0</td>
+        </tr>
+        <tr>
+            <td id="pieceCoin">You will gain a coin from this piece:</td>
         </tr>
     </table>
     <br>


### PR DESCRIPTION
https://github.com/jwyatt1999/CITS3403_Cartographers/issues/2
- [x] Implement full set of explore cards with type swapping, coins (also on mountains), counter for remaining cards this season (and calculation for number of cards this season)

I recommend reviewing https://github.com/jwyatt1999/CITS3403_Cartographers/pull/14 first

In this PR I have implemented coins and the full set of base explore cards. 

Coins can be earned from placing certain explore cards and from surrounding mountains. They give you extra points at the end of each round.

I have implemented the full set of base explore cards, and have added a counter for the remaining number of explore cards this season.

Note: The branch name also includes ambush cards. This has not been implemented in this PR and will be addressed in a future, upcoming PR.

 - [x] Run files through validator
 - [x] Completed plenty of testing